### PR TITLE
Add ProjectsController API and create project endpoint

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -72,7 +72,7 @@ Style/Documentation:
     - 'app/helpers/*'
     - 'app/mailers/*'
     - 'app/models/*'
-    - 'app/controllers/*'
+    - 'app/controllers/**/**/*.rb'
     - 'config/application.rb'
     - 'db/migrate/*'
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ProjectsController < ActionController::API
+      def create
+        @project = Project.new(
+          name: params[:name],
+          description: params[:description],
+          priority: params[:priority]
+        )
+
+        if @project.save
+          head :created
+        else
+          render json: { errors: @project.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/components/Button.jsx
+++ b/app/javascript/components/Button.jsx
@@ -25,14 +25,23 @@ const Button = (props) => {
   }, [isModalOpen]);
 
   const handleFormSubmit = (event) => {
-    event.preventDefault();
     const formData = new FormData(event.target);
     const data = {};
     formData.forEach((value, key) => {
       data[key] = value;
     });
-    console.log(data);
-    // TODO fetch a backend endpoint to create a new project
+
+    fetch('http://localhost:3000/api/v1/projects',
+    {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      method: "POST",
+      body: JSON.stringify(data)
+    })
+      .catch(error => console.error(error))
+      .finally(setIsModalOpen(false));
   };
 
   return (

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,10 @@ Rails.application.routes.draw do
   resources :projects do
     resources :tasks
   end
+
+  namespace :api do
+    namespace :v1 do
+      resources :projects, only: [:create]
+    end
+  end
 end

--- a/spec/controllers/api/v1/projects_controller_spec.rb
+++ b/spec/controllers/api/v1/projects_controller_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::ProjectsController do
+  describe 'POST create' do
+    context 'with valid params' do
+      let(:request) do
+        post :create, params:
+        { name: 'Fix table',
+          description: 'Table has 2 broken legs',
+          priority: 1.2 }
+      end
+
+      it 'creates new project' do
+        expect { request }.to change(Project, :count).by(1)
+      end
+
+      it 'responds with a created status' do
+        request
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:request) do
+        post :create, params:
+        { name: 'Fix table',
+          description: nil,
+          priority: 1.0 }
+      end
+
+      it 'does not create new project' do
+        expect { request }.not_to change(Project, :count)
+      end
+
+      it 'responds with json errors' do
+        request
+        expect(response.body).to include('errors')
+      end
+
+      it 'responds with unprocessable status' do
+        request
+        expect(response).to be_unprocessable
+      end
+    end
+  end
+end


### PR DESCRIPTION
I need to create an API for CRUD actions on projects to be consumed by React components.
In this commit I am adding a create project endpoint and request test.