### PR TITLE
Add status to projects

### DIFF
--- a/db/migrate/20240514204905_add_status_to_projects.rb
+++ b/db/migrate/20240514204905_add_status_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusToProjects < ActiveRecord::Migration[7.1]
+  def change
+    add_column :projects, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_04_110743) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_204905) do
   create_table "projects", force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.float "priority"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "tasks", force: :cascade do |t|


### PR DESCRIPTION
- migration to add a status field to projects objects. These are defined as integers as statuses will be enums in the model