### PR TITLE
Added env support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 !/app/assets/builds/.keep
 
 /node_modules
+# Ignore lock files
+*.lock

--- a/app/javascript/components/Button.jsx
+++ b/app/javascript/components/Button.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { DOMAIN } from 'env';
 
 const Button = (props) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -31,7 +32,7 @@ const Button = (props) => {
       data[key] = value;
     });
 
-    fetch('http://localhost:3000/api/v1/projects',
+    fetch("http://" + DOMAIN + ":3000/api/v1/projects",
     {
       headers: {
         'Accept': 'application/json',

--- a/app/javascript/components/ProjectsIndex.jsx
+++ b/app/javascript/components/ProjectsIndex.jsx
@@ -3,13 +3,14 @@ import ReactDOM from 'react-dom/client';
 import Button from './Button'
 import Loader from './Loader';
 import ProjectsTable from './ProjectsTable';
+import { DOMAIN } from 'env';
 
 const ProjectsIndex = () => {
   const [projects, setProjects] = useState([])
   const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(()=> {
-    fetch("http://localhost:3000/api/v1/projects")
+   useEffect(()=> {
+    fetch("http://" + DOMAIN + ":3000/api/v1/projects")
     .then(response => response.json())
     .then(data => setProjects(data))
     .catch(error => console.log(error))

--- a/bin/dev
+++ b/bin/dev
@@ -7,5 +7,6 @@ fi
 
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
+export DOMAIN="${DOMAIN:=localhost}"
 
 exec foreman start -f Procfile.dev "$@"

--- a/build.mjs
+++ b/build.mjs
@@ -1,0 +1,35 @@
+import * as esbuild from 'esbuild'
+
+// TODO
+// Only watch if --watch arg is passed.
+
+let envPlugin = {
+    name: 'env',
+    setup(build) {
+      // Intercept import paths called "env" so esbuild doesn't attempt
+      // to map them to a file system location. Tag them with the "env-ns"
+      // namespace to reserve them for this plugin.
+      build.onResolve({ filter: /^env$/ }, args => ({
+        path: args.path,
+        namespace: 'env-ns',
+      }))
+  
+      // Load paths tagged with the "env-ns" namespace and behave as if
+      // they point to a JSON file containing the environment variables.
+      build.onLoad({ filter: /.*/, namespace: 'env-ns' }, () => ({
+        contents: JSON.stringify(process.env),
+        loader: 'json',
+      }))
+    },
+  }
+
+let w = await esbuild.context({
+    entryPoints: ['app/javascript/*.*'],
+    bundle: true,
+    outdir: 'app/assets/builds',
+    sourcemap:true,
+    format:'esm',
+    plugins: [envPlugin],
+    // watch: true
+ })
+ await w.watch()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,12 @@
     "tailwindcss": "^3.4.3"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
+    "build": "node ./build.mjs",
+    "buildold": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
     "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
+  },
+  "devDependencies": {
+    "dotenv": "^16.4.5",
+    "esbuild": "0.21.1"
   }
 }


### PR DESCRIPTION
Solution for #32 

Moved esbuild to it's own script and included the envplugin from example https://esbuild.github.io/plugins/#using-plugins

Updated the fetches in the jsx to use the env DOMAIN
DOMAIN will be initialized to localhost by /bin/dev if it's not declared already.